### PR TITLE
Using a monthly cronjob to build the image

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -1,15 +1,14 @@
 name: Docker (Build & Push)
 
 on:
-  push:
-    branches:
-      - master
+  schedule:
+    - cron:  '0 5 1 * *'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 4
-    if: "!contains(github.event.head_commit.message, '[nodoc]')"
+    if: false
     steps:
       - uses: actions/checkout@master
       - uses: docker/build-push-action@v1


### PR DESCRIPTION
I noticed I could auto build on push via https://hub.docker.com/repository/docker/mikerogers0/bridgetownrb-installer/builds.

This instead is now a disabled cronjob which runs at the start of each month