### PR TITLE
Using correct path where build is made

### DIFF
--- a/App-Template/netlify.toml
+++ b/App-Template/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "yarn deploy"
-  publish = "build"
+  publish = "output"
 
 [build.processing]
   skip_processing = false


### PR DESCRIPTION
Bridgetown builds to the `output` folder. Sorting that :D