### PR TITLE
Use default netlify deploy command from Bridgetown

### DIFF
--- a/App-Template/netlify.toml
+++ b/App-Template/netlify.toml
@@ -3,7 +3,6 @@
   publish = "output"
 
 [build.environment]
-  NODE_ENV = "production"
   NODE_VERSION = "12"
   BRIDGETOWN_ENV = "production"
 

--- a/App-Template/netlify.toml
+++ b/App-Template/netlify.toml
@@ -1,6 +1,11 @@
 [build]
-  command = "webpack --mode production && bundle exec bridgetown build"
+  command = "yarn deploy"
   publish = "output"
+
+[build.environment]
+  NODE_ENV = "production"
+  NODE_VERSION = "12"
+  BRIDGETOWN_ENV = "production"
 
 [build.processing]
   skip_processing = false


### PR DESCRIPTION
I experimented a bit more, the reason I previously has problems with my deploys was because I didn't set the NODE_VERSION. This sets it & lets us stick to defaults.