### PR TITLE
Explictly set NODE_ENV on Netlify

### DIFF
--- a/App-Template/netlify.toml
+++ b/App-Template/netlify.toml
@@ -3,6 +3,7 @@
   publish = "output"
 
 [build.environment]
+  NODE_ENV = "development"
   NODE_VERSION = "12"
   BRIDGETOWN_ENV = "production"
 


### PR DESCRIPTION
In a review app I found it was a 50/50 experience whether it'll install NPM dependencies as I expected without `NODE_ENV` set explicitly.