### PR TITLE
Adding MIT License to generated repo

### DIFF
--- a/App-Template/LICENSE
+++ b/App-Template/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Mike Rogers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This adds a MIT License to the generated repo. I decided on MIT because the [main bridgetown repo uses MIT](https://github.com/bridgetownrb/bridgetown/blob/main/LICENSE), though I did use the boilerplate one from GitHub instead of copying theirs.

Thank you @andrewmcodes for suggesting this 👍 

Closes: https://github.com/Ruby-Starter-Kits/Docker-Bridgetown-Generator/issues/22