### PR TITLE
Running container as non-root user

### DIFF
--- a/App-Template/Dockerfile
+++ b/App-Template/Dockerfile
@@ -16,8 +16,18 @@ RUN apk add --no-cache \
 
 FROM builder as development
 
+# Create a non-root user
+# Otherwise folders like node_modules are owned by root.
+ARG USER_ID=${USER_ID:-1000}
+ARG GROUP_ID=${GROUP_ID:-1000}
+ARG DOCKER_USER=${DOCKER_USER:-user}
+
+RUN addgroup -g $GROUP_ID -S $GROUP_ID
+RUN adduser --disabled-password -G $GROUP_ID --uid $USER_ID -S $DOCKER_USER
+
 # Add the current apps files into docker image
 RUN mkdir -p /usr/src/app
+RUN chown -R $USER_ID:$GROUP_ID /usr/src/app
 WORKDIR /usr/src/app
 
 ENV PATH /usr/src/app/bin:$PATH
@@ -27,6 +37,9 @@ RUN bundle config --global silence_root_warning 1
 
 EXPOSE 4000
 CMD ["yarn", "start", "--host", "0.0.0.0"]
+
+# Define the user running the container
+USER $USER_ID:$GROUP_ID
 
 FROM development AS production
 


### PR DESCRIPTION
Right now, the `node_modules` and other bridgetown folders made by the app were being made as the root users on Ubuntu.

This solves that by running the container as the `1000` user.

I copied the approach of @ParamagicDev & @ministryofjustice for this:

- https://github.com/ParamagicDev/bridgetown-automation-docker-compose/blob/master/Dockerfile
- https://github.com/ministryofjustice/correspondence_tool_staff/blob/master/Dockerfile