### PR TITLE
Explicitly sticking to default bundler version

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,6 +17,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.1
+        bundler: none
     - uses: actions/cache@v2
       with:
         path: vendor/bundle

--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -28,6 +28,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.1
+        bundler: none
     - uses: actions/cache@v1.1.2
       with:
         path: ${{ github.workspace }}/vendor/bundle


### PR DESCRIPTION
The action I'm using for installing Ruby made a change where they install a new version of Bundler ( https://github.com/ruby/setup-ruby/commit/c3f248a2823535700e6cc90a4e64cf20d98632a3 ). So locking it to the version which ships with the current ruby version.