### PR TITLE
Setting branch reference when pushing

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,6 +2,9 @@
 name: Changelog
 
 on:
+  workflow_dispatch:
+  release:
+    types: [created]
   push:
     branches:
       - master
@@ -13,21 +16,20 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[nodoc]')"
     steps:
     - uses: actions/checkout@master
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
-        bundler: none
+        ruby-version: 3.0
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-changelog-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gem-
+          ${{ runner.os }}-changelog-gem-
     - name: Create local changes
       run: |
         gem install github_changelog_generator
-        github_changelog_generator -u Ruby-Starter-Kits -p Docker-Bridgetown-Generator --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"
@@ -37,3 +39,4 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}

--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -86,3 +86,4 @@ jobs:
         github_token: ${{ secrets.LOCAL_GIT_TOKEN }}
         repository: 'Ruby-Starter-Kits/Docker-Bridgetown-Template'
         directory: App
+        branch: ${{ github.ref }}


### PR DESCRIPTION
The `ad-m/github-push-action` action changed to push to `main` in https://github.com/ad-m/github-push-action/pull/69 - So explicitly setting the branch reference